### PR TITLE
fix：動畫瘋自動作答失效、修正找不到答案時不會跳彈窗的問題

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,8 +19,6 @@
 // @connect      script.googleusercontent.com
 // @supportURL   https://home.gamer.com.tw/creationDetail.php?sn=3852242
 // @noframes
-// @downloadURL  https://update.greasyfork.org/scripts/36964/%E5%B7%B4%E5%93%88%E5%A7%86%E7%89%B9%E8%87%AA%E5%8B%95%E7%B0%BD%E5%88%B0%EF%BC%88%E5%90%AB%E5%85%AC%E6%9C%83%E3%80%81%E5%8B%95%E7%95%AB%E7%98%8B%EF%BC%89.user.js
-// @updateURL    https://update.greasyfork.org/scripts/36964/%E5%B7%B4%E5%93%88%E5%A7%86%E7%89%B9%E8%87%AA%E5%8B%95%E7%B0%BD%E5%88%B0%EF%BC%88%E5%90%AB%E5%85%AC%E6%9C%83%E3%80%81%E5%8B%95%E7%95%AB%E7%98%8B%EF%BC%89.meta.js
 // ==/UserScript==
 
 (function () {


### PR DESCRIPTION
1、巴哈創作列表原先是直接跟著網頁顯示，現在改成 ajax，所以程式跟著改成抓 API 處理，API 預設抓10筆，現在加上參數只抓最新的一筆，速度更快，並加入簡單的偵錯
2、彈窗不會顯示的問題起因是抓不到資料導致 JS 出錯中斷，把它丟進 if 裡去就可以了
3、console.log 錯誤修正：應該出錯的部份(undefined)卻被顯示了出來
4、強化文章判斷：2024/06/20 發生作者的內文日期正確但標題日期錯誤的情況，所以標題判斷一次後，會再判斷一次內文的日期
